### PR TITLE
Fix width on pages without sidebar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     {% include head/custom.html %}
   </head>
 
-  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{% if site.rtl %}rtl{% else %}ltr{% endif %}">
+  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}{% unless page.author_profile or layout.author_profile or page.sidebar %} no-sidebar{% endunless %}" dir="{% if site.rtl %}rtl{% else %}ltr{% endif %}">
     {% include_cached skip-links.html %}
     {% include_cached masthead.html %}
 

--- a/_sass/_custom-variables.scss
+++ b/_sass/_custom-variables.scss
@@ -2,4 +2,7 @@
 
 // twitter color theme
 $twitter-color: #000;
+
+// expand layout width to reduce whitespace on pages without sidebars
+$max-width: none;
  

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -26,3 +26,9 @@
   color: inherit;
 }
 
+body.no-sidebar .page {
+  float: none;
+  width: 100%;
+  padding-inline-end: 0;
+}
+


### PR DESCRIPTION
## Summary
- add automatic `no-sidebar` class when no sidebar content
- update custom styles so pages without a sidebar use full width

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_684b38bdc35883279827d0e1eda3dc58